### PR TITLE
split match by index and match by name

### DIFF
--- a/parsetag_test.go
+++ b/parsetag_test.go
@@ -65,6 +65,8 @@ func TestFill(t *testing.T) {
 				T3 string `xyz:"a,last" want:"{\"Name\":\"a\",\"First\":false}"`
 				T4 string `xyz:"a,!first" want:"{\"Name\":\"a\",\"First\":false}"`
 				T5 string `xyz:"a,!last" want:"{\"Name\":\"a\",\"First\":true}"`
+				T6 bool   `xyz:"first,first" want:"{\"Name\":\"first\",\"First\":true}"`
+				T7 bool   `xyz:"first,!first" want:"{\"Name\":\"first\",\"First\":false}"`
 			}{},
 			model: struct {
 				Name  string `pf:"0" json:",omitempty"`


### PR DESCRIPTION
fix  
```
struct {
    	T6 bool   `xyz:"first,first" want:"{\"Name\":\"first\",\"First\":true}"`
        T7 bool   `xyz:"first,!first" want:"{\"Name\":\"first\",\"First\":false}"`
}
```
with this line delete(kv, value) will make second first never match. 

ref: https://github.com/muir/reflectutils/pull/22#discussion_r1798039502